### PR TITLE
Återaktiverade integrationstester mot MongoDB

### DIFF
--- a/current-race/src/test/java/se/cag/labs/currentrace/apicontroller/CurrentRaceControllerIT.java
+++ b/current-race/src/test/java/se/cag/labs/currentrace/apicontroller/CurrentRaceControllerIT.java
@@ -46,6 +46,8 @@ import static org.mockito.Mockito.*;
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
 @ActiveProfiles("int-test")
 public class CurrentRaceControllerIT {
+  @Rule
+  public MongoDbRule mongoDbRule = new MongoDbRule(mongoDb().databaseName("test").build());
   @Autowired
   private ApplicationContext applicationContext; //Needed by nosqlunit
   @Autowired
@@ -265,16 +267,18 @@ public class CurrentRaceControllerIT {
   @EnableMongoRepositories
   @Profile("int-test")
   static class MongoConfiguration extends AbstractMongoConfiguration {
+    @Value("${spring.data.mongodb.uri}")
+    String mongoUri;
 
     @Override
     protected String getDatabaseName() {
-      return "fongo-test";
+      return "test";
     }
 
     @Bean
     @Override
     public Mongo mongo() {
-      return new Fongo("test-db").getMongo();
+      return new MongoClient(new MongoClientURI(mongoUri));
     }
 
     @Override

--- a/current-race/src/test/java/se/cag/labs/currentrace/apicontroller/CurrentRaceControllerTest.java
+++ b/current-race/src/test/java/se/cag/labs/currentrace/apicontroller/CurrentRaceControllerTest.java
@@ -31,7 +31,6 @@ import java.util.*;
 
 import static com.jayway.restassured.RestAssured.*;
 import static com.jayway.restassured.RestAssured.when;
-import static com.lordofthejars.nosqlunit.mongodb.MongoDbRule.MongoDbRuleBuilder.*;
 import static org.hamcrest.core.Is.*;
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.eq;
@@ -48,7 +47,6 @@ import static org.mockito.Mockito.*;
 public class CurrentRaceControllerTest {
   @Autowired
   private ApplicationContext applicationContext; //Needed by nosqlunit
-
   @Autowired
   private CurrentRaceRepository repository;
   @Autowired

--- a/current-race/src/test/resources/application-test.properties
+++ b/current-race/src/test/resources/application-test.properties
@@ -1,3 +1,5 @@
+spring.data.mongodb.uri=mongodb://localhost/test
+
 server.port=8080
 
 server.usermanager.base.uri=http://localhost:10280


### PR DESCRIPTION
Återaktiverade MongoDB som en del av integrationstesterna, inaktiverar körning av integrationstester i Jenkins.
